### PR TITLE
feat: 관리자 상품 조회 페이지 - 주문 수량, 전체 수량 표기 추가

### DIFF
--- a/src/main/webapp/WEB-INF/views/admin/books.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/books.jsp
@@ -93,6 +93,9 @@
                         <td><%= dto.getTitle()%>
                         </td>
                         <td>
+                            <%= dto.getOrder_count()%>/<%= dto.getBook_count()%>
+                        </td>
+                        <td>
                             <button type="button" name="editBtn" id="editBtn"
                                     value="<%= dto.getRegistered_book_id()%>"
                                     onclick="editButton(<%= dto.getRegistered_book_id()%>)">edit

--- a/src/main/webapp/resources/js/admin.js
+++ b/src/main/webapp/resources/js/admin.js
@@ -16,7 +16,7 @@ function getBooks(doUrl, jsonData) {
           str += "<tr>"
           str += "<td>" + '<img id="bookImg" src="' + resp[i].image_url + '">' + "</td>"
           str += "<td>" + resp[i].title + "</td>"
-          str += "<td>" + resp[i].order_count + "</td>"
+          str += "<td>" + resp[i].order_count + "/" + resp[i].book_count + "</td>"
           str += "<td>" + "<button type='button' name='editBtn' id='editBtn' value='" + resp[i].registered_book_id + "' onclick=editButton('" + resp[i].registered_book_id + "')>edit</button>" + "</td>"
           str += "<td>" + "<button type='button' name='cancelBtn' id='cancelBtn' value='" + resp[i].registered_book_id + "' onclick=cancelBookButton('" + resp[i].registered_book_id + "')>cancel</button>" + "</td>"
 
@@ -28,6 +28,7 @@ function getBooks(doUrl, jsonData) {
           str += "<tr>"
           str += "<td>" + '<img id="bookImg" src="' + resp[i].image_url + '">' + "</td>"
           str += "<td>" + resp[i].title + "</td>"
+          str += "<td>" + resp[i].order_count + '/' + resp[i].book_count + "</td>"
           str += "<td>" + "<button type='button' name='editBtn' id='editBtn' value='" + resp[i].registered_book_id + "' onclick=editButton('" + resp[i].registered_book_id + "')>edit</button>" + "</td>"
           str += "<td>" + "<button type='button' name='cancelBtn' id='cancelBtn' value='" + resp[i].registered_book_id + "' onclick=cancelBookButton('" + resp[i].registered_book_id + "')>cancel</button>" + "</td>"
 


### PR DESCRIPTION
[작업 동기]
* 관리자의 등록된 상품 목록 조회 시 판매수량과 전체수량을 표기하는 것이 더 보기 좋을 것이라는 판단이 들어 작업을 시작


[작업 내용]
* DTO의 판매수량과 전체수량 값을 table에 추가 표기 #6 